### PR TITLE
Updated create_run_from_openhtf_report syntax

### DIFF
--- a/src/app/api/page.mdx
+++ b/src/app/api/page.mdx
@@ -240,9 +240,6 @@ fetch('https://www.tofupilot.app/api/v1/runs', {
       <Property name="file_path" type="string, required">
         The path to the log file to be imported.
       </Property>
-      <Property name="importer" type="string, optional">
-        The type of importer to use. Defaults to "OPENHTF".
-      </Property>
     </Properties>
   </Col>
 
@@ -255,15 +252,12 @@ from tofupilot import TofuPilotClient
 client = TofuPilotClient()
 
 client.create_run_from_report(
-  file_path="path/to/your/test/report.json",
-  importer="OPENHTF"
-)
+  file_path="path/to/your/test/report.json",)
 ```
 
 ```bash {{ title: 'cURL' }}
 curl -X POST https://www.tofupilot.app/api/v1/import -H "Content-Type: application/json" -H "Authorization: Bearer ${TOFUPILOT_API_KEY}" -d '{
     "file_path": "path/to/your/test/report.json",
-    "importer": "OPENHTF"
 }'
 ```
 
@@ -276,7 +270,6 @@ fetch('https://www.tofupilot.app/api/v1/import', {
   },
   body: JSON.stringify({
     file_path: 'path/to/your/test/report.json',
-    importer: 'OPENHTF',
   }),
 })
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Simplified the API request structure for creating runs from file reports.
	- Updated code examples in various formats to align with the streamlined request payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->